### PR TITLE
Adding necessary puppetlabs/ruby dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,3 +7,5 @@ summary 'Install and manage bundler'
 
 source 'https://github.com/puppetlabs-operations/puppet-bundler'
 project_page 'https://github.com/puppetlabs-operations/puppet-bundler'
+
+dependency 'puppetlabs/ruby', '>= 0.0.2'


### PR DESCRIPTION
Morning!

Your module includes ruby::params but does not specify any dependency. This seems to fix it.
