### PR TITLE
Document ruby dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,12 @@
 puppet-bundler
 ==============
 
-Automatically install ruby dependencies
+Automatically install ruby dependencies.
+
+Dependencies
+------------
+
+- The [`ruby` module](https://github.com/puppetlabs/puppetlabs-ruby) has to be installed alongside this module.
 
 Examples
 --------


### PR DESCRIPTION
Users will get error messages if they don't install the `puppetlabs-ruby` dependency alongside this module.
This changeset makes it clearer from the README.

Related to #1.
