### PR TITLE
Support timeout option

### DIFF
--- a/manifests/bundle.pp
+++ b/manifests/bundle.pp
@@ -1,6 +1,7 @@
 define bundler::bundle (
     $source,
-    $gems
+    $gems,
+    $timeout = 300,
 ){
   include bundler
 
@@ -14,6 +15,7 @@ define bundler::bundle (
     command     => "bundle install",
     cwd         => dirname("${name}"),
     refreshonly => true,
+    timeout     => $timeout,
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,7 @@ define bundler::install(
   $group      = 'root',
   $deployment = false,
   $without    = undef,
+  $timeout    = 300,
 ) {
 
   include ruby::params
@@ -43,5 +44,6 @@ define bundler::install(
     require     => Package['bundler'],
     logoutput   => on_failure,
     environment => "HOME='${name}'",
+    timeout     => $timeout,
   }
 }


### PR DESCRIPTION
Installing all dependencies can be long on large projects. This changeset brings support for providing a `timeout` option. The default value is 300 seconds, the Puppet default.
