### PR TITLE
Support logoutput option

### DIFF
--- a/manifests/bundle.pp
+++ b/manifests/bundle.pp
@@ -1,6 +1,7 @@
 define bundler::bundle (
     $source,
-    $gems
+    $gems,
+    $logoutput = on_failure,
 ){
   include bundler
 
@@ -14,6 +15,7 @@ define bundler::bundle (
     command     => "bundle install",
     cwd         => dirname("${name}"),
     refreshonly => true,
+    logoutput   => $logoutput,
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,7 @@ define bundler::install(
   $group      = 'root',
   $deployment = false,
   $without    = undef,
+  $logoutput  = on_failure,
 ) {
 
   include ruby::params
@@ -41,7 +42,7 @@ define bundler::install(
     path        => "/bin:/usr/bin:/usr/local/bin:${ruby::params::gem_binpath}",
     unless      => 'bundle check',
     require     => Package['bundler'],
-    logoutput   => on_failure,
+    logoutput   => $logoutput,
     environment => "HOME='${name}'",
   }
 }


### PR DESCRIPTION
Installing all dependencies can be long on large projects. If you're in an environment timing outputs to detect stalled processes, puppet-bundler can look like it is stuck.
One can also be interested in detecting the slowest gems to install.

This changeset brings support for providing a `logoutput` option, possibly allowing outputting a line per gem.
The default value stays at `on_failure`, the previous default. Other allowed values are `false` or, more interestingly for the use-case above, `true`.
